### PR TITLE
Track visible Stream Deck dial contexts

### DIFF
--- a/Sources/MyStreamDeckPlugin.h
+++ b/Sources/MyStreamDeckPlugin.h
@@ -21,11 +21,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MyStreamDeckPlugin : NSObject <ESDEventsProtocol>
 
 @property (weak) ESDConnectionManager *connectionManager;
+/// Set of contexts currently visible/active on a dial stack.
+@property (nonatomic, strong) NSMutableSet<NSString *> *visibleContexts;
+
+/// Returns YES if the given context is currently front-most on the dial.
+- (BOOL)isActiveOnDial:(NSString *)context;
 
 - (void)keyDownForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
 - (void)keyUpForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
 - (void)willAppearForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
 - (void)willDisappearForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
+
+// Encoder-related events (Stream Deck+) – gated by isActiveOnDial.
+- (void)dialRotateForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
+- (void)dialDownForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
+- (void)dialUpForAction:(NSString *)action withContext:(id)context withPayload:(NSDictionary *)payload forDevice:(NSString *)deviceID;
 
 - (void)deviceDidConnect:(NSString *)deviceID withDeviceInfo:(NSDictionary *)deviceInfo;
 - (void)deviceDidDisconnect:(NSString *)deviceID;

--- a/Sources/MyStreamDeckPlugin.m
+++ b/Sources/MyStreamDeckPlugin.m
@@ -33,6 +33,13 @@ static void RunOSAString(NSString *source) {
 
 @implementation MyStreamDeckPlugin
 
+- (instancetype)init {
+    if ((self = [super init])) {
+        _visibleContexts = [NSMutableSet set];
+    }
+    return self;
+}
+
 // Called when the Stream Deck app launches any monitored application.
 // (We don’t need to do anything here for OSA Script.)
 - (void)applicationDidLaunch:(NSString *)application
@@ -73,7 +80,8 @@ static void RunOSAString(NSString *source) {
                  withPayload:(NSDictionary *)payload
                   forDevice:(NSString *)deviceID
 {
-    // No-op
+    // Track that this context is now visible/front-most on the dial stack.
+    [self.visibleContexts addObject:context];
 }
 
 // Called when the user removes this action’s button from the screen
@@ -83,7 +91,40 @@ static void RunOSAString(NSString *source) {
                    withPayload:(NSDictionary *)payload
                     forDevice:(NSString *)deviceID
 {
-    // No-op
+    // Remove the context when it leaves the front of the stack.
+    [self.visibleContexts removeObject:context];
+}
+
+- (BOOL)isActiveOnDial:(NSString *)context {
+    return [self.visibleContexts containsObject:context];
+}
+
+// Encoder-related events
+- (void)dialRotateForAction:(NSString *)action
+                withContext:(NSString *)context
+                 withPayload:(NSDictionary *)payload
+                  forDevice:(NSString *)deviceID
+{
+    if (![self isActiveOnDial:context]) return; // ignore if not front-most
+    // Handle rotation here if needed
+}
+
+- (void)dialDownForAction:(NSString *)action
+              withContext:(NSString *)context
+               withPayload:(NSDictionary *)payload
+                forDevice:(NSString *)deviceID
+{
+    if (![self isActiveOnDial:context]) return;
+    // Handle dial press here if needed
+}
+
+- (void)dialUpForAction:(NSString *)action
+            withContext:(NSString *)context
+             withPayload:(NSDictionary *)payload
+              forDevice:(NSString *)deviceID
+{
+    if (![self isActiveOnDial:context]) return;
+    // Handle dial release here if needed
 }
 
 


### PR DESCRIPTION
- Track when an action becomes visible or hidden via `willAppear`/`willDisappear`
- Maintain a `visibleContexts` set and expose `isActiveOnDial:` helper
- Stub out dial event handlers gated by active context